### PR TITLE
Make Imoen's ToB dialogue more stable / prevent stutter in mod setup

### DIFF
--- a/iepbanters/dialogue/imoen25j.d
+++ b/iepbanters/dialogue/imoen25j.d
@@ -1,6 +1,7 @@
 APPEND ~IMOEN25J~
 
-IF ~Global("LK#ImmyImpish","GLOBAL",2) RealGlobalTimerExpired("LK#ImmyImpishTimer","GLOBAL")~ LK#ImmyImpish
+IF WEIGHT #-1
+~Global("LK#ImmyImpish","GLOBAL",2)~ LK#ImmyImpish
   SAY @0
   ++ @1 DO ~IncrementGlobal("LK#ImmyImpish","GLOBAL",1)~ + LK#Impish_why
   ++ @2 DO ~IncrementGlobal("LK#ImmyImpish","GLOBAL",1)~ + LK#Impish_dontremember

--- a/iepbanters/scripts/imoe25.baf
+++ b/iepbanters/scripts/imoe25.baf
@@ -28,7 +28,6 @@ THEN
 END
 
 IF
-    RealGlobalTimerExpired("LK#ImmyImpishTimer","GLOBAL")
     InParty(Myself)
     See(Player1)
     !StateCheck(Player1,CD_STATE_NOTVALID)


### PR DESCRIPTION
-removed over-specification in triggers (removed additional timer checks) 
-added WEIGHT #-1 so dialogue will not be blocked by PID of another mod.

This was a reported stutter with the Imoen Romance mod installed before IEP EB.
https://discord.com/channels/205226905870270466/531043595252137985/1200423970743275620